### PR TITLE
Add Availability Update and Event Update Endpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -156,7 +156,7 @@ async def add_availability(request: Request):
     if availability is None:
         return {"message": "Invalid availability data"}
     result = new_availability(availability, body["event_code"])
-    if result is not bool:
+    if isinstance(result, str):
         return {"message": result}
     elif not result:
         return {"message": "Database error"}
@@ -184,7 +184,7 @@ async def update_availability(request: Request):
     if availability is None:
         return {"message": "Invalid availability data"}
     result = update_avail(availability, body["event_code"])
-    if result is not bool:
+    if isinstance(result, str):
         return {"message": result}
     elif not result:
         return {"message": "Database error"}

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,6 +17,7 @@ from utils import (
     dashboard_data,
     get_event_results,
     update_avail,
+    fix_event,
 )
 from event import Event
 from availability import Availability
@@ -110,6 +111,29 @@ async def create_event(request: Request):
         return {"message": "Database error"}
 
     return {"message": "Event created", "event_code": code}
+
+
+@app.post("/update_event")
+async def update_event(request: Request):
+    body: dict = await request.json()
+    user_id = check_login(body)
+    if user_id < 0:
+        return {"message": "Login failed"}
+    else:
+        body["account_id"] = user_id
+
+    if "event_code" not in body:
+        return {"message": "Missing field: event_code"}
+    if not check_code_event(body["event_code"]):
+        return {"message": "Invalid event code"}
+
+    event_obj = Event.from_json(body)
+    if event_obj is None:
+        return {"message": "Invalid event data"}
+    if not fix_event(event_obj, body["event_code"]):
+        return {"message": "Database error"}
+
+    return {"message": "Event updated"}
 
 
 @app.post("/add_availability")

--- a/backend/app.py
+++ b/backend/app.py
@@ -153,7 +153,7 @@ async def event_details(request: Request):
     if not check_code_event(body["event_code"]):
         return {"message": "Invalid event code"}
 
-    return get_event(body["event_code"]).to_json()
+    return get_event(body["event_code"])
 
 
 @app.post("/dashboard_events")

--- a/backend/app.py
+++ b/backend/app.py
@@ -171,7 +171,7 @@ async def dashboard_events(request: Request):
 
 
 @app.post("/get_results")
-async def dashboard_events(request: Request):
+async def get_results(request: Request):
     body: dict = await request.json()
     user_id = check_login(body)
     if user_id < 0:
@@ -184,4 +184,4 @@ async def dashboard_events(request: Request):
     if not check_code_event(body["event_code"]):
         return {"message": "Invalid event code"}
 
-    return get_results(body["event_code"])
+    return get_event_results(body["event_code"])

--- a/backend/event.py
+++ b/backend/event.py
@@ -78,8 +78,8 @@ class Event(ABC):
         self.creator: User = creator
         self.title: str = title
         self.description: str = description
-        self.start_time: time = (datetime.min + start_time).time()
-        self.end_time: time = (datetime.min + end_time).time()
+        self.start_time: time = start_time
+        self.end_time: time = end_time
         self.duration: Duration = duration
         self.availabilities: List[Availability] = availabilities
 
@@ -167,8 +167,8 @@ class Event(ABC):
                 User(result["user_account_id"]),
                 result["title"],
                 result["details"],
-                result["start_time"],
-                result["end_time"],
+                (datetime.min + result["start_time"]).time(),
+                (datetime.min + result["end_time"]).time(),
                 Duration(result["duration"]),
                 [],
                 result["start_date"],
@@ -179,8 +179,8 @@ class Event(ABC):
                 User(result["user_account_id"]),
                 result["title"],
                 result["details"],
-                result["start_time"],
-                result["end_time"],
+                (datetime.min + result["start_time"]).time(),
+                (datetime.min + result["end_time"]).time(),
                 Duration(result["duration"]),
                 [],
                 date_to_weekday(result["start_date"]),

--- a/backend/event.py
+++ b/backend/event.py
@@ -281,7 +281,7 @@ class DateEvent(Event):
                     AND user_account_id = %s
             """
             cursor.execute(event_query, (code, self.creator.id))
-            event_id = cursor.fetchone()
+            event_id = cursor.fetchone()["user_event_id"]
             update_query = """
                 UPDATE user_event
                 SET
@@ -408,7 +408,7 @@ class GenericWeekEvent(Event):
                     AND user_account_id = %s
             """
             cursor.execute(event_query, (code, self.creator.id))
-            event_id = cursor.fetchone()
+            event_id = cursor.fetchone()["user_event_id"]
             update_query = """
                 UPDATE user_event
                 SET

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -229,6 +229,11 @@ def new_event(event: Event, code: str) -> bool:
     return event.to_sql_insert(DB_CURSOR, DB_CONN, code)
 
 
+# Updates an event in the database
+def fix_event(event: Event, code: str) -> bool:
+    return event.to_sql_update(DB_CURSOR, DB_CONN, code)
+
+
 # Checks if a code refers to an existing event
 def check_code_event(code: str) -> bool:
     try:

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -316,7 +316,7 @@ def dashboard_data(user: User) -> dict:
     return user.get_events(DB_CURSOR)
 
 
-def get_results(code: str) -> List[Availability]:
+def get_event_results(code: str) -> List[Availability]:
     avail_query = """
         SELECT
             user_account_id,

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -254,6 +254,10 @@ def new_availability(availability: Availability, code: str) -> str:
     return availability.to_sql_insert(DB_CURSOR, DB_CONN, code)
 
 
+def update_avail(availability: Availability, code: str) -> str:
+    return availability.to_sql_update(DB_CURSOR, DB_CONN, code)
+
+
 def get_all_dates(start_date, end_date, generic=False):
     start = datetime.strptime(start_date, "%m/%d/%Y")
     end = datetime.strptime(end_date, "%m/%d/%Y")


### PR DESCRIPTION
## What?
This adds two endpoints, `/update_availability` and /`update_event` to the API. It also fixes a bug with using `/create_event` and having the time submitted be counted as the wrong data type.
## Why?
Unsure. I'll let you know in 7-12 business days.
## How?
🤷‍♂️ 
## Testing?
👀