### PR TITLE
Add Date List to Event Details

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -153,7 +153,7 @@ async def event_details(request: Request):
     if not check_code_event(body["event_code"]):
         return {"message": "Invalid event code"}
 
-    return get_event(body["event_code"]).to_json()
+    return get_event(body["event_code"])
 
 
 @app.post("/dashboard_events")

--- a/backend/app.py
+++ b/backend/app.py
@@ -171,7 +171,7 @@ async def dashboard_events(request: Request):
 
 
 @app.post("/get_results")
-async def dashboard_events(request: Request):
+async def get_results(request: Request):
     body: dict = await request.json()
     user_id = check_login(body)
     if user_id < 0:
@@ -184,4 +184,4 @@ async def dashboard_events(request: Request):
     if not check_code_event(body["event_code"]):
         return {"message": "Invalid event code"}
 
-    return get_results(body["event_code"])
+    return get_event_results(body["event_code"])

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -316,7 +316,7 @@ def dashboard_data(user: User) -> dict:
     return user.get_events(DB_CURSOR)
 
 
-def get_results(code: str) -> List[Availability]:
+def get_event_results(code: str) -> List[Availability]:
     avail_query = """
         SELECT
             user_account_id,


### PR DESCRIPTION
## What?
Adds fields to the JSON returned from `/event_details`, which provides a list of dates and weekday names where applicable.
## Why?
Frontend needs the data in a format that's easier to parse, so this accomplishes that.
## How?
The way this is implemented is probably some of the worst code written in the project. We can ignore it.
## Testing?
I tried both types of events, looks fine.