### PR TITLE
Add User in Event Endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -18,6 +18,7 @@ from utils import (
     get_event_results,
     update_avail,
     fix_event,
+    check_user_in_event,
 )
 from event import Event
 from availability import Availability
@@ -238,3 +239,20 @@ async def get_results(request: Request):
         return {"message": "Invalid event code"}
 
     return get_event_results(body["event_code"])
+
+
+@app.post("/user_in_event")
+async def user_in_event(request: Request):
+    body: dict = await request.json()
+    user_id = check_login(body)
+    if user_id < 0:
+        return {"message": "Login failed"}
+    else:
+        body["account_id"] = user_id
+
+    if "event_code" not in body:
+        return {"message": "Missing field: event_code"}
+    if not check_code_event(body["event_code"]):
+        return {"message": "Invalid event code"}
+
+    return check_user_in_event(body)

--- a/backend/availability.py
+++ b/backend/availability.py
@@ -40,7 +40,7 @@ class Availability:
                 time_row,
                 is_available
             FROM
-                availability
+                user_event_availability
                 INNER JOIN url_code USING (user_event_id)
                 INNER JOIN user_event_participant USING (user_event_id, user_account_id)
             WHERE
@@ -57,7 +57,7 @@ class Availability:
         curr_date = None
         for row in cursor.fetchall():
             if row["nickname"] not in avail_grids:
-                avail_grids[row["nickname"]] = [[]]
+                avail_grids[row["nickname"]] = []
                 user_ids[row["nickname"]] = row["user_account_id"]
                 curr_nickname = row["nickname"]
             if row["date_column"] != curr_date:


### PR DESCRIPTION
## What?
Adds the `/user_in_event` endpoint, which returns a user's availability if they have added theirs to the specified event. The format of data to send is as follows:
```
{
    [login info],
    "event_code": string
}
```
## Why?
We need a way to check if a user has availability to edit, and what info to pre-populate the grid with.
## How?
The same as I've been doing every other endpoint, though it required some fixing of the Availability class functions.
## Testing?
I tested both scenarios, with users being in and out of events. Seems to work just fine, using already-implemented methods that have been working for other endpoints.