### PR TITLE
Add .env Support

### DIFF
--- a/src/pages/Availability.jsx
+++ b/src/pages/Availability.jsx
@@ -143,7 +143,7 @@ export default function Availability() {
       } else {
         try {
           const response = await fetch(
-            'http://tomeeto.cs.rpi.edu:8000/create_guest'
+            import.meta.env.VITE_API_HOST + '/create_guest'
           );
           if (response.ok) {
             const responseData = await response.json();
@@ -185,7 +185,7 @@ export default function Availability() {
 
         // Proceed with fetch after check_user completes
         const response = await fetch(
-          'http://tomeeto.cs.rpi.edu:8000/event_details',
+          import.meta.env.VITE_API_HOST + '/event_details',
           {
             method: 'POST',
             headers: {
@@ -429,7 +429,7 @@ export default function Availability() {
 
       try {
         const response = await fetch(
-          'http://tomeeto.cs.rpi.edu:8000/update_availability',
+          import.meta.env.VITE_API_HOST + '/update_availability',
           {
             method: 'POST',
             headers: {
@@ -465,7 +465,7 @@ export default function Availability() {
           credentials.guest_password = guestPW;
           console.log('SET GUEST STUFF');
         } else {
-          await fetch('http://tomeeto.cs.rpi.edu:8000/create_guest', {
+          await fetch(import.meta.env.VITE_API_HOST + '/create_guest', {
             method: 'GET',
             headers: {
               'Content-Type': 'application/json',
@@ -486,7 +486,7 @@ export default function Availability() {
       console.log(credentials);
       try {
         const response = await fetch(
-          'http://tomeeto.cs.rpi.edu:8000/add_availability',
+          import.meta.env.VITE_API_HOST + '/add_availability',
           {
             method: 'POST',
             headers: {

--- a/src/pages/CreateEvent.jsx
+++ b/src/pages/CreateEvent.jsx
@@ -189,7 +189,7 @@ export default function CreateEvent() {
       } else {
         try {
           const response = await fetch(
-            'http://tomeeto.cs.rpi.edu:8000/create_guest'
+            import.meta.env.VITE_API_HOST + '/create_guest'
           );
           if (response.ok) {
             const responseData = await response.json();
@@ -231,7 +231,7 @@ export default function CreateEvent() {
 
     try {
       const response = await fetch(
-        'http://tomeeto.cs.rpi.edu:8000/create_event',
+        import.meta.env.VITE_API_HOST + '/create_event',
         {
           method: 'POST',
           headers: {

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -42,7 +42,7 @@ const check_user = async (dataToUse) => {
     } else {
       try {
         const response = await fetch(
-          'http://tomeeto.cs.rpi.edu:8000/create_guest'
+          import.meta.env.VITE_API_HOST + '/create_guest'
         );
         if (response.ok) {
           const responseData = await response.json();
@@ -133,7 +133,7 @@ export default function Dashboard() {
 
     try {
       const response = await fetch(
-        'http://tomeeto.cs.rpi.edu:8000/dashboard_events',
+        import.meta.env.VITE_API_HOST + '/dashboard_events',
         {
           method: 'POST',
           headers: {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -124,7 +124,8 @@ export default function Login() {
     console.log('login data? ', data);
 
     try {
-      const response = await fetch('http://tomeeto.cs.rpi.edu:8000/login', {
+      console.log(import.meta.env.VITE_API_HOST);
+      const response = await fetch(import.meta.env.VITE_API_HOST + '/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/pages/Results.jsx
+++ b/src/pages/Results.jsx
@@ -31,7 +31,7 @@ const check_user = async (dataToUse) => {
     } else {
       try {
         const response = await fetch(
-          'http://tomeeto.cs.rpi.edu:8000/create_guest'
+          import.meta.env.VITE_API_HOST + '/create_guest'
         );
         if (response.ok) {
           const responseData = await response.json();
@@ -129,7 +129,7 @@ export default function Result() {
       console.log('RANNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN');
 
       // First, fetch event details
-      fetch('http://tomeeto.cs.rpi.edu:8000/event_details', {
+      fetch(import.meta.env.VITE_API_HOST + '/event_details', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -145,7 +145,7 @@ export default function Result() {
           updateEventData(eventDetailsData);
 
           // Next, fetch results using the same credentials
-          //   return fetch('http://tomeeto.cs.rpi.edu:8000/get_results', {
+          //   return fetch(import.meta.env.VITE_API_HOST + '/get_results', {
           //     method: 'POST',
           //     headers: {
           //       'Content-Type': 'application/json',
@@ -292,7 +292,7 @@ export default function Result() {
 
     try {
       const response = await fetch(
-        'http://tomeeto.cs.rpi.edu:8000/get_results',
+        import.meta.env.VITE_API_HOST + '/get_results',
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -343,7 +343,7 @@ export default function Result() {
 
   //   try {
   //     const response = await fetch(
-  //       'http://tomeeto.cs.rpi.edu:8000/get_results',
+  //       import.meta.env.VITE_API_HOST + '/get_results',
   //       {
   //         method: 'POST',
   //         headers: {

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -93,7 +93,7 @@ export default function Signup() {
     };
 
     try {
-      const response = await fetch('http://tomeeto.cs.rpi.edu:8000/signup', {
+      const response = await fetch(import.meta.env.VITE_API_HOST + '/signup', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## What?
This adds support for `.env` files in the frontend, which defines the host address for the API.
The file should be in the following format:
```env
VITE_API_HOST="http://[host]"
```
## Why?
This is to allow for proper local testing that doesn't depend on the hard-coded server URL.
## How?
Vite has built-in functionality for `.env` files.
## Testing?
I tested with the server URL and locally, and they both worked.